### PR TITLE
Implemented CMake build system.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,105 @@
+# Settings passed on the command line:
+#
+# BUILD_SHARED_LIBS
+# PROJECT_STATIC_RUNTIME
+# CBASH_NO_BOOST_ZLIB
+
+##############################
+# General Settings
+##############################
+
+cmake_minimum_required (VERSION 3.0)
+project (CBash)
+
+option(BUILD_SHARED_LIBS "Build a shared library" ON)
+option(PROJECT_STATIC_RUNTIME "Build with static runtime libs (/MT)" ON)
+option(CBASH_NO_BOOST_ZLIB "Build with external Zlib" OFF)
+
+set (Boost_USE_STATIC_LIBS ON)
+set (Boost_USE_MULTITHREADED ON)
+set (Boost_USE_STATIC_RUNTIME PROJECT_STATIC_RUNTIME)
+
+file (GLOB_RECURSE CBASH_FONV "${CMAKE_SOURCE_DIR}/FalloutNewVegas/*.cpp")
+file (GLOB_RECURSE CBASH_OBLIVION "${CMAKE_SOURCE_DIR}/Oblivion/*.cpp")
+file (GLOB_RECURSE CBASH_SKYRIM "${CMAKE_SOURCE_DIR}/Skyrim/*.cpp")
+
+set (CBASH_SRC  "${CMAKE_SOURCE_DIR}/CBash.cpp"
+                "${CMAKE_SOURCE_DIR}/Collection.cpp"
+                "${CMAKE_SOURCE_DIR}/Common.cpp"
+                "${CMAKE_SOURCE_DIR}/GenericChunks.cpp"
+                "${CMAKE_SOURCE_DIR}/GenericRecord.cpp"
+                "${CMAKE_SOURCE_DIR}/ModFile.cpp"
+                "${CMAKE_SOURCE_DIR}/TES4Record.cpp"
+                "${CMAKE_SOURCE_DIR}/TES4RecordAPI.cpp"
+                "${CMAKE_SOURCE_DIR}/Visitors.cpp"
+                "${CMAKE_SOURCE_DIR}/CBash.rc"
+                ${CBASH_FONV}
+                ${CBASH_OBLIVION}
+                ${CBASH_SKYRIM}
+                )
+
+IF (CBASH_NO_BOOST_ZLIB)
+    add_definitions(-DCBASH_NO_BOOST_ZLIB)
+    find_package(Boost REQUIRED COMPONENTS iostreams)
+    find_package(ZLIB REQUIRED)
+    set (CBASH_LIBS ${ZLIB_LIBRARY})
+ELSE ()
+    find_package(Boost REQUIRED COMPONENTS iostreams zlib)
+    find_package(ZLIB)
+    set (CBASH_LIBS "")
+ENDIF ()
+
+# Include source and library directories.
+include_directories ("${CMAKE_SOURCE_DIR}/FalloutNewVegas"
+                     "${CMAKE_SOURCE_DIR}/Oblivion"
+                     "${CMAKE_SOURCE_DIR}/Skyrim"
+                     ${Boost_INCLUDE_DIRS}
+                     ${ZLIB_INCLUDE_DIR})
+
+link_directories ()
+
+
+##############################
+# System-Specific Settings
+##############################
+
+# Settings when compiling for Windows. Since it's a Windows-only app this is always true, but useful to check for copy/paste into other projects.
+IF (CMAKE_SYSTEM_NAME MATCHES "Windows")
+    add_definitions (-DUNICODE -D_UNICODE -DNDEBUG -DWIN32 -D_WINDOWS)
+    IF (BUILD_SHARED_LIBS)
+        add_definitions (-DCBASH_DLL)
+    ELSE ()
+        add_definitions (-DCBASH_STATIC)
+    ENDIF ()
+ENDIF ()
+
+IF (MSVC)
+    IF (MSVC_VERSION EQUAL 1800)
+        set (CMAKE_GENERATOR_TOOLSET "v120_xp" CACHE STRING "Platform Toolset" FORCE)
+    ELSEIF (MSVC_VERSION EQUAL 1700)
+        set (CMAKE_GENERATOR_TOOLSET "v110_xp" CACHE STRING "Platform Toolset" FORCE)
+    ENDIF ()
+
+    # Force static C++ runtime linkage.
+    IF (PROJECT_STATIC_RUNTIME)
+        FOREACH(flag
+            CMAKE_C_FLAGS_RELEASE CMAKE_C_FLAGS_RELWITHDEBINFO
+            CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_DEBUG_INIT
+            CMAKE_CXX_FLAGS_RELEASE  CMAKE_CXX_FLAGS_RELWITHDEBINFO
+            CMAKE_CXX_FLAGS_DEBUG  CMAKE_CXX_FLAGS_DEBUG_INIT)
+            STRING(REPLACE "/MD"  "/MT" "${flag}" "${${flag}}")
+            SET("${flag}" "${${flag}} /EHsc")
+        ENDFOREACH()
+    ENDIF ()
+
+    set (CMAKE_EXE_LINKER_FLAGS "/SUBSYSTEM:WINDOWS")
+ENDIF ()
+
+
+##############################
+# Actual Building
+##############################
+
+# Build CBash.
+add_library           (CBash ${CBASH_SRC})
+target_link_libraries (CBash ${Boost_LIBRARIES} ${CBASH_LIBS})

--- a/Common.cpp
+++ b/Common.cpp
@@ -35,7 +35,7 @@
  * ***** END LICENSE BLOCK ***** */
 // Common.cpp
 #include "Common.h"
-#include "zlib/zlib.h"
+#include "zlib.h"
 #include <sys/utime.h>
 
 int (*printer)(const char * _Format, ...) = &printf;

--- a/GenericRecord.cpp
+++ b/GenericRecord.cpp
@@ -36,7 +36,7 @@
 
 #include "Common.h"
 #include "GenericRecord.h"
-#include "zlib/zlib.h"
+#include "zlib.h"
 
 RecordOp::RecordOp():
     count(0),

--- a/TES4Record.cpp
+++ b/TES4Record.cpp
@@ -36,7 +36,7 @@
 #include "Common.h"
 #include "TES4Record.h"
 #include "Skyrim\SkyrimCommon.h" // StringLookups
-#include "zlib/zlib.h"
+#include "zlib.h"
 
 TES4Record::TES4HEDR::TES4HEDR(FLOAT32 _version, UINT32 _numRecords, UINT32 _nextObject):
     version(_version),

--- a/docs/BUILD.CMAKE.md
+++ b/docs/BUILD.CMAKE.md
@@ -1,0 +1,20 @@
+# Building CBash Using CMake
+
+These instructions were used to build CBash using Microsoft Visual Studio 2012 and Microsoft Visual Studio Express 2013 for Desktop, though they should also apply to other compilers with minimal adaptation.
+
+CBash's CMake configuration builds an executable that can be run on Windows XP, but this support has only been implemented for MSVC 2012 and 2013 - other versions of MSVC may require editing of CBash's [CMakeLists.txt](../CMakeLists.txt) file.
+
+CBash uses the following CMake variables to set build parameters:
+
+Parameter | Values | Description
+----------|--------|------------
+`BUILD_SHARED_LIBS` | `ON`, `OFF` | Whether or not to build a shared CBash binary (DLL). Defaults to `ON`.
+`PROJECT_STATIC_RUNTIME` | `ON`, `OFF` | Whether to link the C++ runtime statically or not. This also affects the Boost libraries used. Defaults to `ON`.
+`CBASH_NO_BOOST_ZLIB` | `ON`, `OFF` | Whether to use the zlib binary distributed with the prebuilt Boost library binaries. Defaults to `OFF`.
+
+Depending on your configuration, you may also need to define the `BOOST_ROOT`, `BOOST_LIBRARYDIR` and `ZLIB_ROOT` folder paths for CMake to find the required libraries. Use the paths you noted down when you installed/extracted the dependencies.
+
+1. Set CMake up so that it builds the binaries in the `build` subdirectory of the CBash folder.
+2. Define any necessary parameters.
+3. Configure CMake, then generate a build system for Visual Studio 2013.
+4. Open the generated solution file, and build it.

--- a/docs/BUILD.MANUAL.md
+++ b/docs/BUILD.MANUAL.md
@@ -1,0 +1,31 @@
+# Building CBash "Manually"
+
+These instructions are for building CBash on Windows by manually creating a Microsoft Visual Studio solution. The instructions were written using MSVC 2013, so slight changes may be required if you are using a different version.
+
+An example of the end result can be found [here](https://drive.google.com/file/d/0B1ddaVyxNcp-ZmpyUENiRFkyUEE/edit?usp=sharing "Google Drive"), though these files are out-of-date compared to the current code, so it's best to create your own solution.
+
+1. Create a new Win32 Application project.  In the creation wizard be sure to select DLL, and tick the Empty Project option.
+2. Now add all the CBash source files to the project.  Personally I make the source layout look mostly identical to the actual file layout on disk.  So I have a `Skyrim`, `Fallout New Vegas`, and `Oblivion` sub-filters for each of the `Source Files` and `Header Files`.  Then under those a sub-filter called `Records`, and under that one called `API`.  Just throw every `*.h` and `*.cpp` file into their appropriate filters in the solution explorer.  Finally add `CBash.rc` into the `Resource Files` section.
+
+  Alternatively, you can try running [this](https://github.com/lojack5/utilities/blob/master/project_update.py) Python script, which should correctly add all required files to the project.  **Note:** That script is written only for Visual Studio 2013, I don't know how or if it will work for other versions.
+3. Change Project settings for `All Configurations`.  The next few steps will all be changing settings under the following section:
+  * Right Click on your project in Visual Studio, select Properties.
+  * In the Property Pages window that pops up, select `All Configurations` from the Configuration drop down.
+  * All changes will be made under the `Configuration Properties` sub tree on the left.
+4. Additional Directories:
+  * Go to `VC++ Directories`.
+  * Edit `Include Directories` so that it includes the path to Boost as well as zlib.
+  * Edit `Library Directories` so that it includes the path to Boost.
+  * If you built the zlib binaries and are going to use those instead of Boost's, add that of course.
+4. Output Files:
+  * Go to `C/C++ -> Output Files`.
+  * Edit both `ASM List Location` and `Object File Name` to `$(IntDir)\%(RelativeDir)`.  Note there is no backslash at the end.  This setting is so files with the same name won't end up making object files that overwrite each other.
+5. Preprocessor:
+  * Go to `C/C++ -> Preprocessor`
+  * Edit `Preprocessor Definitions` to include `_CRT_SECURE_NO_WARNINGS`.  This will stop the compiler from throwing errors for using things like `strncat`.
+6. Additional Configuration (Optional):
+  * CBash uses boost's `auto_link.hpp` to automatically link to the correct boost zlib binary.  If you don't want CBash to use boost's binaries and want to specify your own instead, you need to disable this.  Go to `C/C++ -> Preprocessor -> Preprocessor Definitions` and add `CBASH_NO_BOOST_ZLIB` to the list of definitions.  Then you will need to add your zlib binary under `Linker -> Input -> Additional Dependencies`.
+  * CBash automatically detects how you are using it by looking for the `_USRDLL` preprocessor definition in your project file.  This definition is added by the MSVC project wizard when making a new DLL project, so if CBash isn't detecting this correctly, you have two options:
+    * Add/remove `_USRDLL` from the preprocessor definitions as applicable.
+    * Add/remove `CBASH_DLL` or `CBASH_STATIC` from the preprocessor definitions for your project file to force one or the other.
+    * Optionally, you could also `#define` these in CBash.cpp, before the include for CBash.h

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -1,0 +1,47 @@
+# Building CBash
+
+Two methods of building CBash are documented:
+
+* [Automated](BUILD.CMAKE.md): Using [CMake](http://cmake.org) to generate a Microsoft Visual C++ solution to build.
+* [Manual](BUILD.MANUAL.md): Manually creating a Microsoft Visual C++ solution to build.
+
+The instructions for both methods are tailored to the creation of MSVC 2013 solutions, though the automated method does allow for other build systems and platforms, at the expense of requiring CMake to be installed.
+
+Make sure you have satisfied the dependencies below before following the instructions for either build method.
+
+## Dependencies
+
+CBash depends on two external libraries:
+
+* [Boost](http://www.boost.org)
+* [Zlib](http://zlib.net)
+
+Both libraries can be built from source. However, it is generally easier to install the [prebuilt Boost binaries](http://sourceforge.net/projects/boost/files/boost-binaries/), which also include zlib binaries. Both build methods allow for either approach.
+
+### Using Prebuilt Binaries
+
+If using the prebuilt Boost binaries, download and install them, then make a note of the install path and the path the binary files themselves are found in.
+
+Although it is not necessary to build a zlib binary when using the prebuilt binaries, the header files are still required for linking, so download and extract the zlib source. Make a note of where the source is extracted to.
+
+### Building From Source
+
+If building from source, extract the source archives and make a note of the paths they were extracted to. See the instructions below for how to build them on Windows using MSVC.
+
+#### Boost
+
+The Boost.Iostreams library must be built, which can be done using the commands below.
+
+```
+bootstrap.bat
+b2 toolset=msvc link=static runtime-link=static variant=release address-model=32 --with-iostreams
+```
+
+`link`, `runtime-link` and `address-model` can all be modified if shared linking or 64 bit builds are desired. CBash uses statically-linked Boost libraries by default: to change this, edit [CMakeLists.txt](../CMakeLists.txt).
+
+#### Zlib
+
+There are a variety of ways to build zlib: for details, see the zlib documentation. To build zlib using CMake, do the following:
+
+1. Configure CMake and generate a build system for Visual Studio by running CMake with keys `-DCMAKE_ARCHIVE_OUTPUT_DIRECTORY=build`.
+2. Open the generated solution file, and build target `zlibstatic` with `Release` configuration.


### PR DESCRIPTION
Less setup and maintenance required compared to VS project files, and it means people can build CBash using a variety of compilers.

`ZLIB_ROOT`, `BOOST_ROOT` and `BOOST_LIBRARYDIR` may need to be defined, depending on the setup. I tested on my usual setup (self-built binaries) and the one given on the Building CBash wiki page (pre-built binaries).
