### PR TITLE
Fix - two issues

### DIFF
--- a/src/Skyrim/VMAD/Property/Property.cpp
+++ b/src/Skyrim/VMAD/Property/Property.cpp
@@ -151,8 +151,6 @@ void Property::Read(unsigned char *&buffer, const int16_t &version, const int16_
 void Property::Write(FileWriter &writer)
 {
     // name
-    uint16_t nameSize = (uint16_t)name.GetSize();
-    writer.record_write(&nameSize, sizeof(nameSize));
     name.Write16(writer);
     // type
     writer.record_write(&type, sizeof(type));

--- a/src/Skyrim/VMAD/VMAD.cpp
+++ b/src/Skyrim/VMAD/VMAD.cpp
@@ -70,7 +70,7 @@ void VMADRecord::Load()
 
 void VMADRecord::Unload()
 {
-    for (uint16_t i = 0; i, scripts.size(); ++i)
+    for (uint16_t i = 0; i < scripts.size(); ++i)
         delete scripts[i];
     scripts.clear();
     delete fragment;


### PR DESCRIPTION
1) When unloading VMADs, due to incorrect ( ? ) for loop statement, it would go out of bounds
2) When writing properties, it would write the property name size twice, corrupting the file.